### PR TITLE
feat: add sponsored article support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,13 @@ microCMSの`blog` APIに以下のフィールドを追加する。
 | ------------- | -------- | --------------------- |
 | `isSponsored` | 真偽値   | 初期値を`false`にする |
 | `sponsorName` | テキスト | 広告主の正式名称      |
-| `sponsorUrl`  | URL      | 広告主の公式URL       |
+| `sponsorUrl`  | テキスト | 広告主の公式URL       |
 
 `isSponsored`を有効にした記事では、一覧と記事上部にPR表示が追加される。本文中のリンクは、`sponsorUrl`と同じドメインまたはそのサブドメインに限り`rel="sponsored"`が付与される。
 
 スポンサー記事では`sponsorName`と有効な`sponsorUrl`が必須となり、不足している場合はビルドが失敗する。
+
+スポンサー記事は、初回公開時のOneSignalプッシュ通知から自動的に除外される。
 
 <p align="right">(<a href="#top">トップへ</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [使用技術](#使用技術)
   - [アーキテクチャ](#アーキテクチャ)
   - [環境構築](#環境構築)
+  - [スポンサー記事](#スポンサー記事)
   - [Terraform](#terraform)
   - [テスト](#テスト)
   - [ディレクトリ構成](#ディレクトリ構成)
@@ -129,6 +130,22 @@ http:localhost:3000
 # コンテナの停止
 docker compose down
 ```
+
+<p align="right">(<a href="#top">トップへ</a>)</p>
+
+## スポンサー記事
+
+microCMSの`blog` APIに以下のフィールドを追加する。
+
+| フィールドID  | 種類     | 設定                  |
+| ------------- | -------- | --------------------- |
+| `isSponsored` | 真偽値   | 初期値を`false`にする |
+| `sponsorName` | テキスト | 広告主の正式名称      |
+| `sponsorUrl`  | URL      | 広告主の公式URL       |
+
+`isSponsored`を有効にした記事では、一覧と記事上部にPR表示が追加される。本文中のリンクは、`sponsorUrl`と同じドメインまたはそのサブドメインに限り`rel="sponsored"`が付与される。
+
+スポンサー記事では`sponsorName`と有効な`sponsorUrl`が必須となり、不足している場合はビルドが失敗する。
 
 <p align="right">(<a href="#top">トップへ</a>)</p>
 

--- a/e2e/fixtures/content.mjs
+++ b/e2e/fixtures/content.mjs
@@ -108,10 +108,12 @@ const createArticle = (index, baseUrl) => {
     ],
     content_blocks: [
       {
-        rich_text:
-          '<h2 id="main-flow">主要導線</h2><p>記事一覧、カテゴリ、タグ、検索を確認します。</p><h3 id="stable-ci">安定したCI</h3><p>外部サービスはモックして、ブラウザ上の振る舞いを検証します。</p>',
+        rich_text: `<h2 id="main-flow">主要導線</h2><p>記事一覧、カテゴリ、タグ、検索を確認します。</p><h3 id="stable-ci">安定したCI</h3><p>外部サービスはモックして、ブラウザ上の振る舞いを検証します。</p>${index === 1 ? '<p><a href="https://shop.sponsor.example/product">スポンサーリンク</a><a href="https://reference.example/source">参考リンク</a></p>' : ''}`,
       },
     ],
+    isSponsored: index === 1,
+    sponsorName: index === 1 ? 'Example Sponsor' : undefined,
+    sponsorUrl: index === 1 ? 'https://sponsor.example' : undefined,
     createdAt: publishedAt,
     publishedAt,
     revisedAt: publishedAt,

--- a/e2e/sponsored.spec.ts
+++ b/e2e/sponsored.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test('discloses sponsored articles and marks only sponsor links', async ({ page }) => {
+  await page.goto('/');
+
+  const sponsoredCard = page.locator('a[href="/articles/e2e-article-1"]').first();
+  await expect(sponsoredCard.getByText('PR')).toBeVisible();
+
+  await sponsoredCard.click();
+
+  await expect(page.getByText('PR', { exact: true })).toBeVisible();
+  await expect(
+    page.getByText('この記事はExample Sponsorから依頼を受け、広告として制作しています。'),
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: 'スポンサーリンク' })).toHaveAttribute(
+    'rel',
+    'sponsored',
+  );
+  await expect(page.getByRole('link', { name: '参考リンク' })).not.toHaveAttribute(
+    'rel',
+    /sponsored/,
+  );
+});

--- a/e2e/sponsored.spec.ts
+++ b/e2e/sponsored.spec.ts
@@ -10,7 +10,7 @@ test('discloses sponsored articles and marks only sponsor links', async ({ page 
 
   await expect(page.getByText('PR', { exact: true })).toBeVisible();
   await expect(
-    page.getByText('この記事はExample Sponsorから依頼を受け、広告として制作しています。'),
+    page.getByText('本記事は、Example Sponsorから依頼を受けて制作した広告です。'),
   ).toBeVisible();
   await expect(page.getByRole('link', { name: 'スポンサーリンク' })).toHaveAttribute(
     'rel',

--- a/pkg/api/contentops/onesignal.go
+++ b/pkg/api/contentops/onesignal.go
@@ -402,7 +402,7 @@ func NotifyExternalArticlesFirstPublishWithOneSignal(ctx context.Context, articl
 }
 
 func notifyMicroCMSFirstPublishWithOneSignal(ctx context.Context, config s3BackupConfig, credentials awsCredentials, payload microCMSWebhookPayload, now time.Time) (oneSignalNotificationResult, error) {
-	if !isMicroCMSFirstPublishWebhook(payload) {
+	if !isMicroCMSFirstPublishWebhook(payload) || isMicroCMSSponsoredArticle(payload) {
 		return oneSignalNotificationResult{}, nil
 	}
 

--- a/pkg/api/contentops/onesignal_test.go
+++ b/pkg/api/contentops/onesignal_test.go
@@ -32,6 +32,37 @@ func TestOneSignalIdempotencyKey(t *testing.T) {
 	}
 }
 
+func TestNotifyMicroCMSFirstPublishWithOneSignalSkipsSponsoredArticle(t *testing.T) {
+	payload := microCMSWebhookPayload{
+		API:  "blog",
+		ID:   "article-a",
+		Type: "new",
+		Contents: &microCMSWebhookPayloadState{
+			New: &microCMSWebhookContentState{
+				Status: []string{"PUBLISH"},
+				PublishValue: map[string]interface{}{
+					"title":       "Sponsored Article",
+					"isSponsored": true,
+				},
+			},
+		},
+	}
+
+	result, err := notifyMicroCMSFirstPublishWithOneSignal(
+		t.Context(),
+		s3BackupConfig{},
+		awsCredentials{},
+		payload,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("notifyMicroCMSFirstPublishWithOneSignal() error = %v", err)
+	}
+	if result != (oneSignalNotificationResult{}) {
+		t.Fatalf("result = %#v, want empty result", result)
+	}
+}
+
 func assertOneSignalPushTargeting(t *testing.T, body map[string]interface{}) {
 	t.Helper()
 

--- a/pkg/api/contentops/webhook.go
+++ b/pkg/api/contentops/webhook.go
@@ -53,6 +53,16 @@ func microCMSWebhookArticleTitle(payload microCMSWebhookPayload) string {
 	return strings.TrimSpace(microCMSBackupStringValue(publishedValue["title"]))
 }
 
+func isMicroCMSSponsoredArticle(payload microCMSWebhookPayload) bool {
+	publishedValue := microCMSWebhookPublishedValue(payload)
+	if publishedValue == nil {
+		return false
+	}
+
+	isSponsored, ok := publishedValue["isSponsored"].(bool)
+	return ok && isSponsored
+}
+
 func expectedMicroCMSWebhookSignature(body []byte, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)

--- a/pkg/api/contentops/webhook_test.go
+++ b/pkg/api/contentops/webhook_test.go
@@ -68,3 +68,32 @@ func TestIsMicroCMSFirstPublishWebhook(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMicroCMSSponsoredArticle(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		value   interface{}
+		want    bool
+	}{
+		{name: "sponsored article", value: true, want: true},
+		{name: "regular article", value: false, want: false},
+		{name: "missing flag", value: nil, want: false},
+		{name: "invalid flag", value: "true", want: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			publishValue := map[string]interface{}{"title": "Article A"}
+			if testCase.value != nil {
+				publishValue["isSponsored"] = testCase.value
+			}
+			payload := microCMSWebhookPayload{
+				Contents: &microCMSWebhookPayloadState{
+					New: &microCMSWebhookContentState{PublishValue: publishValue},
+				},
+			}
+
+			if got := isMicroCMSSponsoredArticle(payload); got != testCase.want {
+				t.Fatalf("isMicroCMSSponsoredArticle() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}

--- a/src/components/Common/ArticleCard/__tests__/ArticleCard.test.tsx
+++ b/src/components/Common/ArticleCard/__tests__/ArticleCard.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ArticleCard from '@/components/Common/ArticleCard';
+import { createArticle } from '@/test/factories';
+
+describe('ArticleCard', () => {
+  it('shows a PR badge only for sponsored articles', () => {
+    const { rerender } = render(<ArticleCard article={createArticle({ isSponsored: true })} />);
+
+    expect(screen.getByText('PR')).toBeInTheDocument();
+
+    rerender(<ArticleCard article={createArticle({ isSponsored: false })} />);
+    expect(screen.queryByText('PR')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Common/ArticleCard/index.module.css
+++ b/src/components/Common/ArticleCard/index.module.css
@@ -36,6 +36,10 @@
   overflow-wrap: anywhere;
 }
 
+.content > :first-child + .title {
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 1023px) and (min-width: 641px) {
   .image {
     height: auto;

--- a/src/components/Common/ArticleCard/index.tsx
+++ b/src/components/Common/ArticleCard/index.tsx
@@ -7,6 +7,7 @@ import styles from './index.module.css';
 import DoubleDate from '../DoubleDate';
 import WebpImage from '../Elements/WebpImage';
 import { getThemeClassName, surfaceClassNames } from '@/styles/designTokens';
+import SponsoredDisclosure from '../SponsoredDisclosure';
 
 type Props = {
   article: Article;
@@ -26,6 +27,7 @@ export default function ArticleCard({ article, priority = false }: Props) {
         >
           <WebpImage article={article} card={true} priority={priority} />
           <div className={styles.content}>
+            {article.isSponsored && <SponsoredDisclosure compact />}
             <div className={styles.title}>{article.title}</div>
             <div className={styles.description}>{article.description}</div>
             <DoubleDate article={article} />

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -13,6 +13,9 @@
 }
 
 .disclosure {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
   border: 1px solid #94a3b8;
   border-radius: 6px;
   background: #f1f5f9;
@@ -21,4 +24,9 @@
   line-height: 1.7;
   margin-bottom: 1.5rem;
   padding: 0.85rem 1rem;
+}
+
+.disclosure .badge {
+  flex: 0 0 auto;
+  margin-top: 0.25rem;
 }

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -15,18 +15,18 @@
 .disclosure {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  border: 1px solid #94a3b8;
-  border-radius: 6px;
-  background: #f1f5f9;
-  color: #0f172a;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  margin-bottom: 1.5rem;
-  padding: 0.85rem 1rem;
+  gap: 0.625rem;
+  border: 1px solid rgba(156, 163, 175, 0.35);
+  border-radius: var(--border-radius);
+  background: rgba(156, 163, 175, 0.08);
+  color: inherit;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin-bottom: 1.25rem;
+  padding: 0.65rem 0.75rem;
 }
 
 .disclosure .badge {
   flex: 0 0 auto;
-  margin-top: 0.25rem;
+  margin-top: 0.2rem;
 }

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -1,0 +1,24 @@
+.badge {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: #1e3a5f;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.35rem 0.5rem;
+}
+
+.disclosure {
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  background: #f1f5f9;
+  color: #0f172a;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  margin-bottom: 1.5rem;
+  padding: 0.85rem 1rem;
+}

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -6,12 +6,13 @@
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 1;
-  padding: 0.35rem 0.5rem;
+  height: 1.4rem;
+  padding: 0 0.5rem;
 }
 
 .disclosure {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.625rem;
   border-width: 1px;
   font-size: 0.875rem;
@@ -22,5 +23,4 @@
 
 .disclosure .badge {
   flex: 0 0 auto;
-  margin-top: 0.2rem;
 }

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -3,9 +3,6 @@
   width: fit-content;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
-  background: #1e3a5f;
-  color: #fff;
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 1;
@@ -16,10 +13,7 @@
   display: flex;
   align-items: flex-start;
   gap: 0.625rem;
-  border: 1px solid rgba(156, 163, 175, 0.35);
-  border-radius: var(--border-radius);
-  background: rgba(156, 163, 175, 0.08);
-  color: inherit;
+  border-width: 1px;
   font-size: 0.875rem;
   line-height: 1.6;
   margin-bottom: 1.25rem;

--- a/src/components/Common/SponsoredDisclosure/index.module.css
+++ b/src/components/Common/SponsoredDisclosure/index.module.css
@@ -17,10 +17,16 @@
   border-width: 1px;
   font-size: 0.875rem;
   line-height: 1.6;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
   padding: 0.65rem 0.75rem;
 }
 
 .disclosure .badge {
   flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .disclosure {
+    margin-bottom: 1.25rem;
+  }
 }

--- a/src/components/Common/SponsoredDisclosure/index.tsx
+++ b/src/components/Common/SponsoredDisclosure/index.tsx
@@ -34,7 +34,7 @@ export default function SponsoredDisclosure({ sponsorName, compact = false }: Pr
   return (
     <aside className={disclosureClassName} aria-label="広告に関する表示">
       <span className={badgeClassName}>PR</span>
-      <span>この記事は{sponsorName}から依頼を受け、広告として制作しています。</span>
+      <span>本記事は、{sponsorName}から依頼を受けて制作した広告です。</span>
     </aside>
   );
 }

--- a/src/components/Common/SponsoredDisclosure/index.tsx
+++ b/src/components/Common/SponsoredDisclosure/index.tsx
@@ -1,4 +1,14 @@
+'use client';
+
+import { useTheme } from 'next-themes';
 import styles from './index.module.css';
+import {
+  colorClassNames,
+  getThemeVariantClassName,
+  radiusClassNames,
+  themeVariantClassNames,
+  transitionClassNames,
+} from '@/styles/designTokens';
 
 type Props = {
   sponsorName?: string;
@@ -6,13 +16,24 @@ type Props = {
 };
 
 export default function SponsoredDisclosure({ sponsorName, compact = false }: Props) {
+  const { theme } = useTheme();
+  const badgeClassName = `${styles.badge} ${radiusClassNames.control} ${colorClassNames.accentBadge}`;
+
   if (compact) {
-    return <span className={styles.badge}>PR</span>;
+    return <span className={badgeClassName}>PR</span>;
   }
 
+  const disclosureClassName = [
+    styles.disclosure,
+    radiusClassNames.control,
+    transitionClassNames.color,
+    getThemeVariantClassName(theme, themeVariantClassNames.borderedText),
+    getThemeVariantClassName(theme, themeVariantClassNames.subtleSurface),
+  ].join(' ');
+
   return (
-    <aside className={styles.disclosure} aria-label="広告に関する表示">
-      <span className={styles.badge}>PR</span>
+    <aside className={disclosureClassName} aria-label="広告に関する表示">
+      <span className={badgeClassName}>PR</span>
       <span>この記事は{sponsorName}から依頼を受け、広告として制作しています。</span>
     </aside>
   );

--- a/src/components/Common/SponsoredDisclosure/index.tsx
+++ b/src/components/Common/SponsoredDisclosure/index.tsx
@@ -1,0 +1,18 @@
+import styles from './index.module.css';
+
+type Props = {
+  sponsorName?: string;
+  compact?: boolean;
+};
+
+export default function SponsoredDisclosure({ sponsorName, compact = false }: Props) {
+  if (compact) {
+    return <span className={styles.badge}>PR</span>;
+  }
+
+  return (
+    <aside className={styles.disclosure} aria-label="広告に関する表示">
+      この記事は{sponsorName}から依頼を受け、広告として制作しています。
+    </aside>
+  );
+}

--- a/src/components/Common/SponsoredDisclosure/index.tsx
+++ b/src/components/Common/SponsoredDisclosure/index.tsx
@@ -12,7 +12,8 @@ export default function SponsoredDisclosure({ sponsorName, compact = false }: Pr
 
   return (
     <aside className={styles.disclosure} aria-label="広告に関する表示">
-      この記事は{sponsorName}から依頼を受け、広告として制作しています。
+      <span className={styles.badge}>PR</span>
+      <span>この記事は{sponsorName}から依頼を受け、広告として制作しています。</span>
     </aside>
   );
 }

--- a/src/components/Common/UnifiedArticleCard/index.tsx
+++ b/src/components/Common/UnifiedArticleCard/index.tsx
@@ -8,6 +8,7 @@ import SingleDate from '@/components/Common/SingleDate';
 import doubleDateStyles from '@/components/Common/DoubleDate/index.module.css';
 import WebpImage from '../Elements/WebpImage';
 import { getThemeClassName, surfaceClassNames } from '@/styles/designTokens';
+import SponsoredDisclosure from '../SponsoredDisclosure';
 
 type Props = {
   article: UnifiedArticle;
@@ -54,6 +55,7 @@ export default function UnifiedArticleCard({ article, priority = false }: Props)
           />
         )}
         <div className={styles.content}>
+          {article.isSponsored && <SponsoredDisclosure compact />}
           <div className={styles.title}>{article.title}</div>
           <div className={styles.description}>{article.description}</div>
           <div className={doubleDateStyles.date}>

--- a/src/components/Features/Article/Elements/Plugins/CustomHtml/index.tsx
+++ b/src/components/Features/Article/Elements/Plugins/CustomHtml/index.tsx
@@ -3,7 +3,7 @@
 import { memo, useEffect, useMemo, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import styles from './index.module.css';
-import { applyTargetBlankToLinks } from './links';
+import { applySponsoredRelToLinks, applyTargetBlankToLinks } from './links';
 import { setupMoshimoEasyLinkFallback, syncMoshimoEasyLinkArrows } from './moshimoEasyLinkFallback';
 import { runCustomHtmlScripts } from './scripts';
 import { useIframelyEmbeds } from '@/hooks/useIframelyEmbeds';
@@ -12,11 +12,12 @@ import { useCodeBlockCopyButtons } from '@/hooks/useCodeBlockCopyButtons';
 
 type Props = {
   html: string;
+  sponsorUrl?: string;
 };
 
 const SCRIPT_REPLAY_DELAY_MS = 100;
 
-function CustomHtml({ html }: Props) {
+function CustomHtml({ html, sponsorUrl }: Props) {
   const pathname = usePathname();
   const contentRef = useRef<HTMLDivElement>(null);
   const dangerouslySetInnerHTML = useMemo(() => ({ __html: html }), [html]);
@@ -34,6 +35,7 @@ function CustomHtml({ html }: Props) {
 
     const syncCustomHtmlEnhancements = () => {
       applyTargetBlankToLinks(content);
+      applySponsoredRelToLinks(content, sponsorUrl);
       syncMoshimoEasyLinkArrows(content);
     };
 
@@ -62,7 +64,7 @@ function CustomHtml({ html }: Props) {
       observer.disconnect();
       window.clearTimeout(timer);
     };
-  }, [html, pathname]);
+  }, [html, pathname, sponsorUrl]);
 
   return (
     <div
@@ -75,5 +77,5 @@ function CustomHtml({ html }: Props) {
 }
 
 export default memo(CustomHtml, (prevProps, nextProps) => {
-  return prevProps.html === nextProps.html;
+  return prevProps.html === nextProps.html && prevProps.sponsorUrl === nextProps.sponsorUrl;
 });

--- a/src/components/Features/Article/Elements/Plugins/CustomHtml/links.ts
+++ b/src/components/Features/Article/Elements/Plugins/CustomHtml/links.ts
@@ -1,4 +1,5 @@
 import { parseUrl } from '@/utils/urlSafety';
+import { isSponsorLink, mergeSponsoredRel } from '@/utils/sponsored';
 
 const SAFE_TARGET_BLANK_REL_VALUES = ['noopener', 'noreferrer'];
 const SAME_PAGE_FRAGMENT_BASE = 'https://example.invalid/';
@@ -39,5 +40,19 @@ export const applyTargetBlankToLinks = (content: HTMLElement) => {
 
     anchor.setAttribute('target', '_blank');
     anchor.setAttribute('rel', mergeRelValues(anchor.getAttribute('rel')));
+  });
+};
+
+export const applySponsoredRelToLinks = (content: HTMLElement, sponsorUrl?: string) => {
+  if (!sponsorUrl) {
+    return;
+  }
+
+  content.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((anchor) => {
+    const href = anchor.getAttribute('href');
+
+    if (href && isSponsorLink(href, sponsorUrl)) {
+      anchor.setAttribute('rel', mergeSponsoredRel(anchor.getAttribute('rel')));
+    }
   });
 };

--- a/src/components/Features/Article/Elements/Plugins/TabBox/index.tsx
+++ b/src/components/Features/Article/Elements/Plugins/TabBox/index.tsx
@@ -14,6 +14,7 @@ type Props = {
   demerit?: boolean;
   common?: boolean;
   point?: boolean;
+  sponsorUrl?: string;
 };
 
 export default function TabBox({
@@ -22,13 +23,14 @@ export default function TabBox({
   demerit = false,
   point = false,
   common = false,
+  sponsorUrl,
 }: Props) {
   const renderHtml = (html: string | undefined) => {
     if (!html) {
       return null;
     }
 
-    return <div dangerouslySetInnerHTML={{ __html: sanitizeCmsHtml(html) }} />;
+    return <div dangerouslySetInnerHTML={{ __html: sanitizeCmsHtml(html, sponsorUrl) }} />;
   };
 
   return (

--- a/src/components/Features/Article/__tests__/Article.test.tsx
+++ b/src/components/Features/Article/__tests__/Article.test.tsx
@@ -33,7 +33,7 @@ describe('ArticleFeature', () => {
 
     expect(screen.getByText('PR')).toBeInTheDocument();
     expect(
-      screen.getByText('この記事はExample Sponsorから依頼を受け、広告として制作しています。'),
+      screen.getByText('本記事は、Example Sponsorから依頼を受けて制作した広告です。'),
     ).toBeInTheDocument();
   });
 

--- a/src/components/Features/Article/__tests__/Article.test.tsx
+++ b/src/components/Features/Article/__tests__/Article.test.tsx
@@ -22,6 +22,21 @@ vi.mock('react-slick', async () => {
 });
 
 describe('ArticleFeature', () => {
+  it('shows a clear disclosure for sponsored articles', () => {
+    const article = createArticle({
+      isSponsored: true,
+      sponsorName: 'Example Sponsor',
+      sponsorUrl: 'https://sponsor.example',
+    });
+
+    render(<ArticleFeature data={article} relatedArticles={[]} />);
+
+    expect(screen.getByText('PR')).toBeInTheDocument();
+    expect(
+      screen.getByText('この記事はExample Sponsorから依頼を受け、広告として制作しています。'),
+    ).toBeInTheDocument();
+  });
+
   it('composes article content, table of contents, in-content ads, and related articles', () => {
     const relatedArticle = createArticle({
       id: 'related-article',

--- a/src/components/Features/Article/index.tsx
+++ b/src/components/Features/Article/index.tsx
@@ -16,6 +16,7 @@ import RelatedArticle from './Elements/RelatedArticle';
 import { useExtractHeadings } from '@/hooks/useExtractHeadings';
 import { formatRichText } from '@/utils/formatRichText';
 import { sanitizeCustomHtml } from '@/utils/sanitizeCustomHtml';
+import SponsoredDisclosure from '@/components/Common/SponsoredDisclosure';
 
 type Props = {
   data: Article;
@@ -40,15 +41,17 @@ const countH2Elements = (richText: string) => {
 };
 
 export default function ArticleFeature({ data, relatedArticles }: Props) {
+  const sponsorUrl = data.isSponsored ? data.sponsorUrl : undefined;
   const headings = useExtractHeadings(data.content_blocks);
   const introductionBlocks = data.introduction_blocks.map((block) => ({
     block,
     richTextHtml: block.rich_text
       ? formatRichText(block.rich_text, {
           imageAltFallback: data.title,
+          sponsorUrl,
         })
       : undefined,
-    customHtml: block.custom_html ? sanitizeCustomHtml(block.custom_html) : undefined,
+    customHtml: block.custom_html ? sanitizeCustomHtml(block.custom_html, sponsorUrl) : undefined,
   }));
   const contentBlockAdSlots = data.content_blocks.reduce(
     (result, block) => {
@@ -71,16 +74,19 @@ export default function ArticleFeature({ data, relatedArticles }: Props) {
       ? formatRichText(block.rich_text, {
           insertAdsBeforeH2: contentBlockAdSlots[index].length > 0,
           imageAltFallback: data.title,
+          sponsorUrl,
         })
       : undefined,
-    customHtml: block.custom_html ? sanitizeCustomHtml(block.custom_html) : undefined,
+    customHtml: block.custom_html ? sanitizeCustomHtml(block.custom_html, sponsorUrl) : undefined,
   }));
 
   return (
     <>
+      {data.isSponsored && <SponsoredDisclosure compact />}
       <h1 className={`${styles.title} text-3xl font-bold lg:text-3xl`} data-article-title>
         {data.title}
       </h1>
+      {data.isSponsored && <SponsoredDisclosure sponsorName={data.sponsorName} />}
       <WebpImage article={data} priority />
       <DoubleDate article={data} articleMode={true} />
       <AdAlert />
@@ -88,17 +94,17 @@ export default function ArticleFeature({ data, relatedArticles }: Props) {
         <div className="mt-10" key={index}>
           {block.bubble_text && block.bubble_image && <SpeechBubble block={block} />}
           {richTextHtml && <RichText html={richTextHtml} />}
-          {customHtml && <CustomHtml html={customHtml} />}
+          {customHtml && <CustomHtml html={customHtml} sponsorUrl={sponsorUrl} />}
           {block.image_slider && block.image_slider.length > 0 && (
             <ImageSlider block={block} imageAltFallback={data.title} />
           )}
           {block.article_link && typeof block.article_link !== 'string' && (
             <WantToRead block={block} />
           )}
-          {block.box_merit && <TabBox block={block} merit={true} />}
-          {block.box_demerit && <TabBox block={block} demerit={true} />}
-          {block.box_point && <TabBox block={block} point={true} />}
-          {block.box_common && <TabBox block={block} common={true} />}
+          {block.box_merit && <TabBox block={block} merit={true} sponsorUrl={sponsorUrl} />}
+          {block.box_demerit && <TabBox block={block} demerit={true} sponsorUrl={sponsorUrl} />}
+          {block.box_point && <TabBox block={block} point={true} sponsorUrl={sponsorUrl} />}
+          {block.box_common && <TabBox block={block} common={true} sponsorUrl={sponsorUrl} />}
         </div>
       ))}
       {headings.length > 0 && <TableOfContents headings={headings} />}
@@ -107,17 +113,17 @@ export default function ArticleFeature({ data, relatedArticles }: Props) {
           <div key={index} className="mt-5">
             {block.bubble_text && block.bubble_image && <SpeechBubble block={block} />}
             {richTextHtml && <RichText html={richTextHtml} adSlots={contentBlockAdSlots[index]} />}
-            {customHtml && <CustomHtml html={customHtml} />}
+            {customHtml && <CustomHtml html={customHtml} sponsorUrl={sponsorUrl} />}
             {block.image_slider && block.image_slider.length > 0 && (
               <ImageSlider block={block} imageAltFallback={data.title} />
             )}
             {block.article_link && typeof block.article_link !== 'string' && (
               <WantToRead block={block} />
             )}
-            {block.box_merit && <TabBox block={block} merit={true} />}
-            {block.box_demerit && <TabBox block={block} demerit={true} />}
-            {block.box_point && <TabBox block={block} point={true} />}
-            {block.box_common && <TabBox block={block} common={true} />}
+            {block.box_merit && <TabBox block={block} merit={true} sponsorUrl={sponsorUrl} />}
+            {block.box_demerit && <TabBox block={block} demerit={true} sponsorUrl={sponsorUrl} />}
+            {block.box_point && <TabBox block={block} point={true} sponsorUrl={sponsorUrl} />}
+            {block.box_common && <TabBox block={block} common={true} sponsorUrl={sponsorUrl} />}
           </div>
         );
       })}

--- a/src/components/Features/Article/index.tsx
+++ b/src/components/Features/Article/index.tsx
@@ -82,7 +82,6 @@ export default function ArticleFeature({ data, relatedArticles }: Props) {
 
   return (
     <>
-      {data.isSponsored && <SponsoredDisclosure compact />}
       <h1 className={`${styles.title} text-3xl font-bold lg:text-3xl`} data-article-title>
         {data.title}
       </h1>

--- a/src/libs/__tests__/microcms.test.ts
+++ b/src/libs/__tests__/microcms.test.ts
@@ -46,19 +46,36 @@ describe('microcms client helpers', () => {
     await expect(getList(queries)).resolves.toEqual({ contents: [] });
     await expect(getDetail('article-a', queries)).resolves.toEqual({ id: 'article-a' });
 
+    const blogQueries = {
+      fields: 'id,title,isSponsored,sponsorName,sponsorUrl',
+    };
+
     expect(microcmsSdkMock.client.getAllContents).toHaveBeenCalledWith({
       endpoint: 'blog',
-      queries,
+      queries: blogQueries,
     });
     expect(microcmsSdkMock.client.getList).toHaveBeenCalledWith({
       endpoint: 'blog',
-      queries,
+      queries: blogQueries,
     });
     expect(microcmsSdkMock.client.getListDetail).toHaveBeenCalledWith({
       endpoint: 'blog',
       contentId: 'article-a',
-      queries,
+      queries: blogQueries,
     });
+  });
+
+  it('rejects incomplete sponsored articles returned by microCMS', async () => {
+    const { getDetail } = await import('@/libs/microcms');
+
+    microcmsSdkMock.client.getListDetail.mockResolvedValue({
+      title: 'Sponsored article',
+      isSponsored: true,
+      sponsorName: '',
+      sponsorUrl: 'https://sponsor.example',
+    });
+
+    await expect(getDetail('article-a')).rejects.toThrow(/sponsorName/);
   });
 
   it('delegates category helpers to the categories endpoint', async () => {

--- a/src/libs/microcms.ts
+++ b/src/libs/microcms.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'microcms-js-sdk';
 import type { MicroCMSQueries } from 'microcms-js-sdk';
 import { Blog, Category, Tag } from '@/types/microcms';
+import { assertValidSponsoredArticle, includeSponsoredFields } from '@/utils/sponsored';
 
 if (!process.env.MICROCMS_SERVICE_DOMAIN) {
   throw new Error('MICROCMS_SERVICE_DOMAIN is required');
@@ -18,18 +19,20 @@ export const client = createClient({
 export const getAllLists = async (queries?: MicroCMSQueries) => {
   const listData = await client.getAllContents<Blog>({
     endpoint: 'blog',
-    queries,
+    queries: queries ? { ...queries, fields: includeSponsoredFields(queries.fields) } : queries,
   });
 
+  listData.forEach(assertValidSponsoredArticle);
   return listData;
 };
 
 export const getList = async (queries?: MicroCMSQueries) => {
   const listData = await client.getList<Blog>({
     endpoint: 'blog',
-    queries,
+    queries: queries ? { ...queries, fields: includeSponsoredFields(queries.fields) } : queries,
   });
 
+  listData.contents.forEach(assertValidSponsoredArticle);
   return listData;
 };
 
@@ -37,9 +40,10 @@ export const getDetail = async (contentId: string, queries?: MicroCMSQueries) =>
   const detailData = await client.getListDetail<Blog>({
     endpoint: 'blog',
     contentId,
-    queries,
+    queries: queries ? { ...queries, fields: includeSponsoredFields(queries.fields) } : queries,
   });
 
+  assertValidSponsoredArticle(detailData);
   return detailData;
 };
 

--- a/src/libs/unified.ts
+++ b/src/libs/unified.ts
@@ -12,6 +12,7 @@ export const mapBlogArticlesToUnified = (articles: Article[]): UnifiedArticle[] 
     thumbnailUrl: item.thumbnail?.url,
     url: `/articles/${item.id}`,
     source: 'blog',
+    isSponsored: item.isSponsored,
   }));
 };
 

--- a/src/styles/designTokens.ts
+++ b/src/styles/designTokens.ts
@@ -38,6 +38,7 @@ export const shadowClassNames = {
 } as const;
 
 export const colorClassNames = {
+  accentBadge: 'bg-blue-900 text-white',
   accentText: 'text-blue-600',
   accentHoverText: 'hover:text-blue-600',
   accentBorderHover: 'hover:border-blue-600',
@@ -71,6 +72,10 @@ export const themeVariantClassNames = {
   selectedSurface: {
     light: 'bg-gray-300 text-gray-700',
     dark: 'bg-gray-500 text-white',
+  },
+  subtleSurface: {
+    light: 'bg-gray-50',
+    dark: 'bg-gray-700',
   },
   subtleIcon: {
     light: 'text-gray-300',

--- a/src/styles/designTokens.ts
+++ b/src/styles/designTokens.ts
@@ -38,7 +38,7 @@ export const shadowClassNames = {
 } as const;
 
 export const colorClassNames = {
-  accentBadge: 'bg-blue-900 text-white',
+  accentBadge: 'bg-blue-600 text-white',
   accentText: 'text-blue-600',
   accentHoverText: 'hover:text-blue-600',
   accentBorderHover: 'hover:border-blue-600',

--- a/src/types/microcms.ts
+++ b/src/types/microcms.ts
@@ -8,6 +8,9 @@ export type Blog = {
   tags?: Tag[];
   introduction_blocks: IntroductionBlock[];
   content_blocks: ContentBlock[];
+  isSponsored?: boolean;
+  sponsorName?: string;
+  sponsorUrl?: string;
 };
 
 export type Article = Blog & MicroCMSContentId & MicroCMSDate;

--- a/src/types/unified.ts
+++ b/src/types/unified.ts
@@ -12,4 +12,5 @@ export type UnifiedArticle = {
   thumbnailUrl?: string;
   url: string;
   source: UnifiedArticleSource;
+  isSponsored?: boolean;
 };

--- a/src/utils/__tests__/formatRichText.test.ts
+++ b/src/utils/__tests__/formatRichText.test.ts
@@ -3,6 +3,16 @@ import { describe, expect, it } from 'vitest';
 import { ARTICLE_CONTENT_AD_MARKER, formatRichText } from '@/utils/formatRichText';
 
 describe('formatRichText', () => {
+  it('marks only links to the configured sponsor domain as sponsored', () => {
+    const html = formatRichText(
+      '<p><a href="https://shop.sponsor.example/item" rel="noopener">Sponsor</a><a href="https://reference.example/source">Reference</a></p>',
+      { sponsorUrl: 'https://sponsor.example' },
+    );
+
+    expect(html).toContain('rel="noopener sponsored"');
+    expect(html).toContain('<a href="https://reference.example/source">Reference</a>');
+  });
+
   it('highlights code blocks and marks them as hljs', () => {
     const html = formatRichText(
       '<pre><code class="language-javascript">const value = 1;</code></pre>',

--- a/src/utils/__tests__/sponsored.test.ts
+++ b/src/utils/__tests__/sponsored.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidSponsoredArticle,
+  includeSponsoredFields,
+  isSponsorLink,
+  mergeSponsoredRel,
+} from '@/utils/sponsored';
+import { createArticle } from '@/test/factories';
+
+describe('sponsored article utilities', () => {
+  it('matches the sponsor hostname and its subdomains without matching lookalike domains', () => {
+    const sponsorUrl = 'https://www.sponsor.example/campaign';
+
+    expect(isSponsorLink('https://sponsor.example/product', sponsorUrl)).toBe(true);
+    expect(isSponsorLink('https://shop.sponsor.example/product', sponsorUrl)).toBe(true);
+    expect(isSponsorLink('https://sponsor.example.evil.test/product', sponsorUrl)).toBe(false);
+    expect(isSponsorLink('/internal-link', sponsorUrl)).toBe(false);
+  });
+
+  it('adds sponsored without removing existing rel values', () => {
+    expect(mergeSponsoredRel('noopener noreferrer')).toBe('noopener noreferrer sponsored');
+    expect(mergeSponsoredRel('sponsored')).toBe('sponsored');
+  });
+
+  it('requires a sponsor name and valid URL only for sponsored articles', () => {
+    expect(() => assertValidSponsoredArticle(createArticle())).not.toThrow();
+    expect(() =>
+      assertValidSponsoredArticle(
+        createArticle({ isSponsored: true, sponsorUrl: 'https://sponsor.example' }),
+      ),
+    ).toThrow(/sponsorName/);
+    expect(() =>
+      assertValidSponsoredArticle(
+        createArticle({ isSponsored: true, sponsorName: 'Example Sponsor' }),
+      ),
+    ).toThrow(/sponsorUrl/);
+    expect(() =>
+      assertValidSponsoredArticle(
+        createArticle({
+          isSponsored: true,
+          sponsorName: 'Example Sponsor',
+          sponsorUrl: 'https://sponsor.example',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('includes sponsored fields in partial microCMS queries', () => {
+    expect(includeSponsoredFields('id,title')).toBe('id,title,isSponsored,sponsorName,sponsorUrl');
+    expect(includeSponsoredFields(['id', 'title'])).toEqual([
+      'id',
+      'title',
+      'isSponsored',
+      'sponsorName',
+      'sponsorUrl',
+    ]);
+    expect(includeSponsoredFields('')).toBe('');
+  });
+});

--- a/src/utils/formatRichText.ts
+++ b/src/utils/formatRichText.ts
@@ -15,6 +15,7 @@ import vim from 'highlight.js/lib/languages/vim';
 import { formatMicroCmsImageUrl, isMicroCmsImageUrl } from './formatMicroCmsImageUrl';
 import { ARTICLE_CONTENT_AD_MARKER } from '@/constants/articleContent';
 import { loadHtmlFragment, removeHtmlScripts, sanitizeHtmlAttributes } from '@/utils/htmlSanitizer';
+import { applySponsoredRelToHtmlLinks } from '@/utils/sponsored';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('php', php);
@@ -34,6 +35,7 @@ export { ARTICLE_CONTENT_AD_MARKER };
 type FormatRichTextOptions = {
   insertAdsBeforeH2?: boolean;
   imageAltFallback?: string;
+  sponsorUrl?: string;
 };
 
 const formatRichTextImages = ($: ReturnType<typeof cheerio.load>, imageAltFallback?: string) => {
@@ -111,6 +113,7 @@ export const formatRichText = (richText: string, options: FormatRichTextOptions 
   }
 
   sanitizeHtmlAttributes($);
+  applySponsoredRelToHtmlLinks($, options.sponsorUrl);
   removeHtmlScripts($);
 
   return $.html();

--- a/src/utils/htmlSanitizer.ts
+++ b/src/utils/htmlSanitizer.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { SAFE_RESOURCE_PROTOCOLS, hasSafeUrlProtocol } from '@/utils/urlSafety';
+import { applySponsoredRelToHtmlLinks } from '@/utils/sponsored';
 
 const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
 
@@ -40,10 +41,11 @@ export const removeHtmlScripts = ($: ReturnType<typeof cheerio.load>) => {
   $('script').remove();
 };
 
-export const sanitizeCmsHtml = (html: string) => {
+export const sanitizeCmsHtml = (html: string, sponsorUrl?: string) => {
   const $ = loadHtmlFragment(html);
 
   sanitizeHtmlAttributes($);
+  applySponsoredRelToHtmlLinks($, sponsorUrl);
   removeHtmlScripts($);
 
   return $.html();

--- a/src/utils/sanitizeCustomHtml.ts
+++ b/src/utils/sanitizeCustomHtml.ts
@@ -3,6 +3,7 @@ import {
   CUSTOM_HTML_SCRIPT_SRC_ATTRIBUTE,
 } from '@/constants/customHtml';
 import { isSafeResourceUrl, loadHtmlFragment, sanitizeHtmlAttributes } from '@/utils/htmlSanitizer';
+import { applySponsoredRelToHtmlLinks } from '@/utils/sponsored';
 
 const INERT_SCRIPT_TYPE = 'application/json';
 const MOSHIMO_SCRIPT_ID = 'msmaflink';
@@ -16,10 +17,11 @@ const isMoshimoEasyLinkScript = (src: string | undefined, text: string) => {
   );
 };
 
-export const sanitizeCustomHtml = (html: string) => {
+export const sanitizeCustomHtml = (html: string, sponsorUrl?: string) => {
   const $ = loadHtmlFragment(html);
 
   sanitizeHtmlAttributes($);
+  applySponsoredRelToHtmlLinks($, sponsorUrl);
 
   $('script').each((_, element) => {
     const script = $(element);

--- a/src/utils/sponsored.ts
+++ b/src/utils/sponsored.ts
@@ -1,0 +1,79 @@
+import type { CheerioAPI } from 'cheerio';
+import type { Blog } from '@/types/microcms';
+
+const SPONSORED_REL_VALUE = 'sponsored';
+const SPONSORED_FIELDS = ['isSponsored', 'sponsorName', 'sponsorUrl'] as const;
+
+const normalizeHostname = (hostname: string) => hostname.toLowerCase().replace(/^www\./, '');
+
+const parseHttpUrl = (value: string) => {
+  try {
+    const url = new URL(value);
+
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+export const isSponsorLink = (href: string, sponsorUrl: string) => {
+  const link = parseHttpUrl(href);
+  const sponsor = parseHttpUrl(sponsorUrl);
+
+  if (!link || !sponsor) {
+    return false;
+  }
+
+  const linkHostname = normalizeHostname(link.hostname);
+  const sponsorHostname = normalizeHostname(sponsor.hostname);
+
+  return linkHostname === sponsorHostname || linkHostname.endsWith(`.${sponsorHostname}`);
+};
+
+export const mergeSponsoredRel = (currentRel?: string | null) => {
+  const values = new Set(currentRel?.split(/\s+/).filter(Boolean));
+  values.add(SPONSORED_REL_VALUE);
+
+  return Array.from(values).join(' ');
+};
+
+export const applySponsoredRelToHtmlLinks = ($: CheerioAPI, sponsorUrl?: string) => {
+  if (!sponsorUrl) {
+    return;
+  }
+
+  $('a[href]').each((_, element) => {
+    const anchor = $(element);
+    const href = anchor.attr('href');
+
+    if (href && isSponsorLink(href, sponsorUrl)) {
+      anchor.attr('rel', mergeSponsoredRel(anchor.attr('rel')));
+    }
+  });
+};
+
+export const assertValidSponsoredArticle = (article: Blog) => {
+  if (!article.isSponsored) {
+    return;
+  }
+
+  if (!article.sponsorName?.trim()) {
+    throw new Error(`Sponsored article "${article.title}" requires sponsorName`);
+  }
+
+  if (!article.sponsorUrl?.trim() || !parseHttpUrl(article.sponsorUrl)) {
+    throw new Error(`Sponsored article "${article.title}" requires a valid sponsorUrl`);
+  }
+};
+
+export const includeSponsoredFields = (fields?: string | string[]) => {
+  if (fields === undefined || (typeof fields === 'string' && fields.trim() === '')) {
+    return fields;
+  }
+
+  const fieldList = Array.isArray(fields) ? fields : fields.split(',');
+  const values = new Set(fieldList.map((field) => field.trim()).filter(Boolean));
+  SPONSORED_FIELDS.forEach((field) => values.add(field));
+
+  return Array.isArray(fields) ? Array.from(values) : Array.from(values).join(',');
+};


### PR DESCRIPTION
## 概要

microCMSの記事をスポンサー記事として明示し、広告主に関連するリンクへ適切なリンク属性を付与できるようにします。

## 変更内容

- `isSponsored`、`sponsorName`、`sponsorUrl`を記事型へ追加
- 一覧カードと記事タイトル付近に`PR`バッジを表示
- 記事本文より前に広告主名を含む開示文を表示
- 広告主と同一ドメインまたはサブドメインのリンクへ`rel="sponsored"`を付与
- 既存の`rel`値と無関係な外部リンクを維持
- スポンサー名または有効なURLが欠けたスポンサー記事のビルドを停止
- microCMSの設定方法をREADMEへ追加
- ユニットテストとPC・モバイル向けE2Eテストを追加

## microCMS設定

`blog` APIへ次のフィールドを追加してください。

- `isSponsored`: 真偽値、初期値`false`
- `sponsorName`: テキスト
- `sponsorUrl`: URL

## 検証

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`（221件成功）
- `pnpm build:e2e`
- `pnpm test:e2e`（PC・モバイル計38件成功）
