### PR TITLE
perf: 検索APIの初回応答を高速化

### DIFF
--- a/pkg/api/search/cache.go
+++ b/pkg/api/search/cache.go
@@ -26,6 +26,7 @@ func resetMicroCMSSearchCache() {
 
 	microCMSSearchCache.serviceDomain = ""
 	microCMSSearchCache.apiKey = ""
+	microCMSSearchCache.query = ""
 	microCMSSearchCache.articles = nil
 	microCMSSearchCache.expiresAt = time.Time{}
 }
@@ -38,12 +39,14 @@ func resetZennSearchCache() {
 	zennSearchCache.expiresAt = time.Time{}
 }
 
-func cachedMicroCMSSearchArticles(serviceDomain, apiKey string) ([]map[string]interface{}, error) {
+func cachedMicroCMSSearchArticles(serviceDomain, apiKey, query string) ([]map[string]interface{}, error) {
 	now := microCMSSearchNow()
+	normalizedQuery := normalizedSearchText(query)
 
 	microCMSSearchCache.RLock()
 	if microCMSSearchCache.serviceDomain == serviceDomain &&
 		microCMSSearchCache.apiKey == apiKey &&
+		microCMSSearchCache.query == normalizedQuery &&
 		now.Before(microCMSSearchCache.expiresAt) {
 		articles := cloneSearchArticles(microCMSSearchCache.articles)
 		microCMSSearchCache.RUnlock()
@@ -51,7 +54,7 @@ func cachedMicroCMSSearchArticles(serviceDomain, apiKey string) ([]map[string]in
 	}
 	microCMSSearchCache.RUnlock()
 
-	articles, err := fetchMicroCMSSearchArticles(serviceDomain, apiKey)
+	articles, err := fetchMicroCMSSearchArticles(serviceDomain, apiKey, query)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +62,7 @@ func cachedMicroCMSSearchArticles(serviceDomain, apiKey string) ([]map[string]in
 	microCMSSearchCache.Lock()
 	microCMSSearchCache.serviceDomain = serviceDomain
 	microCMSSearchCache.apiKey = apiKey
+	microCMSSearchCache.query = normalizedQuery
 	microCMSSearchCache.articles = cloneSearchArticles(articles)
 	microCMSSearchCache.expiresAt = now.Add(microCMSSearchCacheTTL)
 	microCMSSearchCache.Unlock()

--- a/pkg/api/search/config.go
+++ b/pkg/api/search/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	microCMSSearchFields    = "id,title,description,thumbnail,categories,tags,introduction_blocks,content_blocks,publishedAt,updatedAt"
+	microCMSSearchFields    = "id,title,description,thumbnail,publishedAt,updatedAt"
 	microCMSListFetchLimit  = 100
 	microCMSSearchLimit     = 10
 	microCMSSearchLimitMax  = 50
@@ -35,6 +35,7 @@ var (
 		sync.RWMutex
 		serviceDomain string
 		apiKey        string
+		query         string
 		articles      []map[string]interface{}
 		expiresAt     time.Time
 	}{}

--- a/pkg/api/search/handler.go
+++ b/pkg/api/search/handler.go
@@ -82,7 +82,7 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 	defer zennCancel()
 	zennResultCh := requestZennSearchArticles(zennContext)
 
-	articles, err := cachedMicroCMSSearchArticles(serviceDomain, apiKey)
+	articles, err := cachedMicroCMSSearchArticles(serviceDomain, apiKey, query)
 	if err != nil {
 		log.Printf("Failed to request microCMS search: %v", err)
 		monitoring.CaptureError(err, monitoring.EventContext{
@@ -94,7 +94,7 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchedArticles := filterSearchArticles(articles, query)
+	matchedArticles := rankMicroCMSSearchArticles(articles, query)
 	matchedBlogArticles := microCMSSearchArticlesToUnifiedArticles(matchedArticles)
 
 	matchedZennArticles := []map[string]interface{}{}
@@ -115,6 +115,7 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 	matchedUnifiedArticles := combineSearchArticles(matchedBlogArticles, matchedZennArticles)
 	paginatedArticles := projectSearchResponseArticles(paginateSearchArticles(matchedUnifiedArticles, limit, offset))
 
+	w.Header().Set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=3600")
 	httpx.WriteJSON(w, http.StatusOK, searchResponse{
 		Contents:   paginatedArticles,
 		TotalCount: len(matchedUnifiedArticles),

--- a/pkg/api/search/handler_test.go
+++ b/pkg/api/search/handler_test.go
@@ -62,8 +62,8 @@ func TestSearchHandlerSuccess(t *testing.T) {
 				t.Fatalf("host = %q, want %q", r.URL.Host, "example.microcms.test")
 			}
 
-			if got := r.URL.Query().Get("q"); got != "" {
-				t.Fatalf("q = %q, want empty", got)
+			if got := r.URL.Query().Get("q"); got != "React" {
+				t.Fatalf("q = %q, want %q", got, "React")
 			}
 
 			if got := r.URL.Query().Get("limit"); got != "100" {
@@ -109,8 +109,12 @@ func TestSearchHandlerSuccess(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 
-	if got := compactJSON(rec.Body.String()); got != `{"contents":[{"description":"React description","id":"blog-article-b","publishedAt":"2024-01-03T00:00:00.000Z","source":"blog","title":"Article B","url":"/articles/article-b"},{"description":"Body match","id":"blog-article-c","publishedAt":"2024-01-02T00:00:00.000Z","source":"blog","title":"Article C","url":"/articles/article-c"}],"totalCount":3,"offset":1,"limit":2}` {
+	if got := compactJSON(rec.Body.String()); got != `{"contents":[{"description":"React description","id":"blog-article-b","publishedAt":"2024-01-03T00:00:00.000Z","source":"blog","title":"Article B","url":"/articles/article-b"},{"description":"Body match","id":"blog-article-c","publishedAt":"2024-01-02T00:00:00.000Z","source":"blog","title":"Article C","url":"/articles/article-c"}],"totalCount":4,"offset":1,"limit":2}` {
 		t.Fatalf("body = %q", got)
+	}
+
+	if got := rec.Header().Get("Cache-Control"); got != "public, s-maxage=300, stale-while-revalidate=3600" {
+		t.Fatalf("Cache-Control = %q", got)
 	}
 }
 
@@ -223,7 +227,7 @@ func TestSearchHandlerContinuesWhenZennRSSFails(t *testing.T) {
 	}
 }
 
-func TestSearchHandlerUsesCachedMicroCMSArticles(t *testing.T) {
+func TestSearchHandlerCachesMicroCMSArticlesPerQuery(t *testing.T) {
 	resetMicroCMSSearchCache()
 	t.Cleanup(resetMicroCMSSearchCache)
 	mockZennSearchFeed(t, `<rss><channel></channel></rss>`)
@@ -262,7 +266,7 @@ func TestSearchHandlerUsesCachedMicroCMSArticles(t *testing.T) {
 		microCMSSearchNow = originalNow
 	})
 
-	for _, rawURL := range []string{"/api/search?q=React", "/api/search?q=Body"} {
+	for _, rawURL := range []string{"/api/search?q=React", "/api/search?q=React", "/api/search?q=Body"} {
 		req := httptest.NewRequest(http.MethodGet, rawURL, nil)
 		rec := httptest.NewRecorder()
 
@@ -273,12 +277,12 @@ func TestSearchHandlerUsesCachedMicroCMSArticles(t *testing.T) {
 		}
 	}
 
-	if requestCount != 1 {
-		t.Fatalf("microCMS request count = %d, want 1", requestCount)
+	if requestCount != 2 {
+		t.Fatalf("microCMS request count = %d, want 2", requestCount)
 	}
 
 	now = now.Add(microCMSSearchCacheTTL + time.Second)
-	req := httptest.NewRequest(http.MethodGet, "/api/search?q=React", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/search?q=Body", nil)
 	rec := httptest.NewRecorder()
 
 	SearchHandler(rec, req)
@@ -287,8 +291,8 @@ func TestSearchHandlerUsesCachedMicroCMSArticles(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 
-	if requestCount != 2 {
-		t.Fatalf("microCMS request count after expiry = %d, want 2", requestCount)
+	if requestCount != 3 {
+		t.Fatalf("microCMS request count after expiry = %d, want 3", requestCount)
 	}
 }
 

--- a/pkg/api/search/matcher.go
+++ b/pkg/api/search/matcher.go
@@ -168,3 +168,22 @@ func filterSearchArticles(articles []map[string]interface{}, query string) []map
 
 	return matchedArticles
 }
+
+func rankMicroCMSSearchArticles(articles []map[string]interface{}, query string) []map[string]interface{} {
+	rankedArticles := make([]map[string]interface{}, 0, len(articles))
+	terms := searchTerms(query)
+
+	for _, article := range articles {
+		score := articleSearchScore(article, terms)
+		if score == 0 {
+			// microCMS may match text fields that are not included in the compact response.
+			score = 1
+		}
+
+		rankedArticle := cloneSearchArticle(article)
+		rankedArticle[searchScoreField] = score
+		rankedArticles = append(rankedArticles, rankedArticle)
+	}
+
+	return rankedArticles
+}

--- a/pkg/api/search/matcher_test.go
+++ b/pkg/api/search/matcher_test.go
@@ -30,3 +30,22 @@ func TestArticleMatchesSearchQueryTargetsLegacyFields(t *testing.T) {
 		t.Fatal("articleMatchesSearchQuery() matched tag text, want false")
 	}
 }
+
+func TestRankMicroCMSSearchArticlesKeepsMatchesFromOmittedFields(t *testing.T) {
+	articles := []map[string]interface{}{
+		{
+			"id":          "body-match",
+			"title":       "Unrelated title",
+			"description": "Unrelated description",
+		},
+	}
+
+	rankedArticles := rankMicroCMSSearchArticles(articles, "React")
+	if len(rankedArticles) != 1 {
+		t.Fatalf("ranked article count = %d, want 1", len(rankedArticles))
+	}
+
+	if got, ok := rankedArticles[0][searchScoreField].(int); !ok || got != 1 {
+		t.Fatalf("search score = %#v, want 1", rankedArticles[0][searchScoreField])
+	}
+}

--- a/pkg/api/search/microcms.go
+++ b/pkg/api/search/microcms.go
@@ -5,21 +5,31 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"NextBlogApp/pkg/api/microcms"
 )
 
 type microCMSSearchListResponse = microcms.ListResponse
 
-func buildMicroCMSSearchRequest(serviceDomain, apiKey string, limit, offset int) (*http.Request, error) {
-	return microcms.BuildListRequest(context.Background(), microCMSSearchAPIBaseURL, serviceDomain, apiKey, microCMSSearchFields, limit, offset)
+func buildMicroCMSSearchRequest(serviceDomain, apiKey, query string, limit, offset int) (*http.Request, error) {
+	req, err := microcms.BuildListRequest(context.Background(), microCMSSearchAPIBaseURL, serviceDomain, apiKey, microCMSSearchFields, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	params := req.URL.Query()
+	params.Set("q", strings.TrimSpace(query))
+	req.URL.RawQuery = params.Encode()
+
+	return req, nil
 }
 
-func fetchMicroCMSSearchArticles(serviceDomain, apiKey string) ([]map[string]interface{}, error) {
+func fetchMicroCMSSearchArticles(serviceDomain, apiKey, query string) ([]map[string]interface{}, error) {
 	articles := []map[string]interface{}{}
 
 	for offset := 0; ; offset += microCMSListFetchLimit {
-		req, err := buildMicroCMSSearchRequest(serviceDomain, apiKey, microCMSListFetchLimit, offset)
+		req, err := buildMicroCMSSearchRequest(serviceDomain, apiKey, query, microCMSListFetchLimit, offset)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/search/microcms_test.go
+++ b/pkg/api/search/microcms_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBuildMicroCMSSearchRequest(t *testing.T) {
-	req, err := buildMicroCMSSearchRequest("example", "api-key", 10, 20)
+	req, err := buildMicroCMSSearchRequest("example", "api-key", "React hooks", 10, 20)
 	if err != nil {
 		t.Fatalf("buildMicroCMSSearchRequest() error = %v", err)
 	}
@@ -15,7 +15,7 @@ func TestBuildMicroCMSSearchRequest(t *testing.T) {
 		t.Fatalf("method = %s, want GET", req.Method)
 	}
 
-	if req.URL.String() != "https://example.microcms.io/api/v1/blog?fields=id%2Ctitle%2Cdescription%2Cthumbnail%2Ccategories%2Ctags%2Cintroduction_blocks%2Ccontent_blocks%2CpublishedAt%2CupdatedAt&limit=10&offset=20" {
+	if req.URL.String() != "https://example.microcms.io/api/v1/blog?fields=id%2Ctitle%2Cdescription%2Cthumbnail%2CpublishedAt%2CupdatedAt&limit=10&offset=20&q=React+hooks" {
 		t.Fatalf("url = %q", req.URL.String())
 	}
 

--- a/src/components/Common/ArticleList/__tests__/ArticleList.test.tsx
+++ b/src/components/Common/ArticleList/__tests__/ArticleList.test.tsx
@@ -40,6 +40,21 @@ describe('ArticleList', () => {
     expect(screen.getByTestId('share')).toBeInTheDocument();
   });
 
+  it('renders an optional empty-state action', () => {
+    render(
+      <ArticleList
+        articles={[]}
+        tags={tags}
+        archiveList={archiveList}
+        emptyMessage="検索に失敗しました"
+        emptyAction={<button type="button">もう一度検索する</button>}
+      />,
+    );
+
+    expect(screen.getByText('検索に失敗しました')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'もう一度検索する' })).toBeInTheDocument();
+  });
+
   it('renders skeleton items while loading', () => {
     render(<ArticleList articles={[]} tags={tags} archiveList={archiveList} isLoading />);
 

--- a/src/components/Common/ArticleList/index.tsx
+++ b/src/components/Common/ArticleList/index.tsx
@@ -24,13 +24,22 @@ type Props = {
   archiveList: ArchiveItem[];
   mixedArticles?: UnifiedArticle[];
   emptyMessage?: string;
+  emptyAction?: ReactNode;
   isLoading?: boolean;
   stackedPagination?: ReactNode;
 };
 
 const skeletonItems = [0, 1, 2];
 
-function EmptyState({ message, theme }: { message: string; theme?: string }) {
+function EmptyState({
+  action,
+  message,
+  theme,
+}: {
+  action?: ReactNode;
+  message: string;
+  theme?: string;
+}) {
   const colorClassName = getMutedTextClassName(theme);
 
   return (
@@ -40,6 +49,7 @@ function EmptyState({ message, theme }: { message: string; theme?: string }) {
         aria-hidden="true"
       />
       <p className={`text-sm font-medium ${colorClassName}`}>{message}</p>
+      {action && <div className="mt-4 flex justify-center">{action}</div>}
     </div>
   );
 }
@@ -51,6 +61,7 @@ export default function ArticleList({
   archiveList,
   mixedArticles,
   emptyMessage = '記事はまだありません',
+  emptyAction,
   isLoading = false,
   stackedPagination,
 }: Props) {
@@ -76,10 +87,10 @@ export default function ArticleList({
             </ul>
           )}
           {!isLoading && !isMixed && articles.length === 0 && (
-            <EmptyState message={emptyMessage} theme={theme} />
+            <EmptyState action={emptyAction} message={emptyMessage} theme={theme} />
           )}
           {!isLoading && isMixed && mixedArticles && mixedArticles.length === 0 && (
-            <EmptyState message={emptyMessage} theme={theme} />
+            <EmptyState action={emptyAction} message={emptyMessage} theme={theme} />
           )}
           {!isLoading && !isMixed && articles.length > 0 && (
             <ul className={styles.main}>

--- a/src/components/Pages/Search/__tests__/Search.test.tsx
+++ b/src/components/Pages/Search/__tests__/Search.test.tsx
@@ -1,4 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SearchPage from '@/components/Pages/Search';
 import { createArticle, createTag, createUnifiedArticle } from '@/test/factories';
@@ -27,6 +29,7 @@ vi.mock('@/components/Common/ArticleList', () => ({
     articles: { title: string }[];
     mixedArticles?: { title: string }[];
     emptyMessage: string;
+    emptyAction?: ReactNode;
     isLoading?: boolean;
   }) => {
     articleListMock(props);
@@ -38,6 +41,7 @@ vi.mock('@/components/Common/ArticleList', () => ({
           <div key={article.title}>{article.title}</div>
         ))}
         {!props.isLoading && visibleArticles.length === 0 && <div>{props.emptyMessage}</div>}
+        {props.emptyAction}
       </div>
     );
   },
@@ -67,6 +71,7 @@ describe('SearchPage', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete process.env.NEXT_PUBLIC_API_SEARCH_URL;
     vi.unstubAllGlobals();
   });
@@ -144,6 +149,35 @@ describe('SearchPage', () => {
     expect(screen.queryByText('検索中...')).not.toBeInTheDocument();
   });
 
+  it('stops loading and shows retry UI when the request times out', async () => {
+    vi.useFakeTimers();
+    window.history.pushState({}, '', '/search?q=React');
+    fetchMock.mockImplementation(
+      (_url: RequestInfo | URL, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    render(<SearchPage tags={[]} archiveList={[]} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+
+    expect(
+      screen.getByText('検索に失敗しました。時間をおいて再度お試しください。'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'もう一度検索する' })).toBeInTheDocument();
+    expect(articleListMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isLoading: false,
+      }),
+    );
+  });
+
   it('does not fetch until a query is provided', () => {
     render(<SearchPage tags={[]} archiveList={[]} />);
 
@@ -184,9 +218,16 @@ describe('SearchPage', () => {
     expect(articleListMock).not.toHaveBeenCalled();
   });
 
-  it('does not show API errors to users', async () => {
+  it('shows API errors and retries the search', async () => {
     window.history.pushState({}, '', '/search?q=React');
-    fetchMock.mockRejectedValue(new Error('network error'));
+    fetchMock.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        contents: [createArticle({ id: 'react-article', title: 'React article' })],
+        totalCount: 1,
+      }),
+    });
+    const user = userEvent.setup();
 
     render(<SearchPage tags={[]} archiveList={[]} />);
 
@@ -195,15 +236,19 @@ describe('SearchPage', () => {
         expect.objectContaining({
           articles: [],
           mixedArticles: [],
-          emptyMessage: '記事はまだありません',
+          emptyMessage: '検索に失敗しました。時間をおいて再度お試しください。',
           isLoading: false,
         }),
       ),
     );
 
-    expect(screen.getByText('記事はまだありません')).toBeInTheDocument();
     expect(
-      screen.queryByText('検索に失敗しました。時間をおいて再度お試しください。'),
-    ).not.toBeInTheDocument();
+      screen.getByText('検索に失敗しました。時間をおいて再度お試しください。'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'もう一度検索する' }));
+
+    expect(await screen.findByText('React article')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/Pages/Search/__tests__/Search.test.tsx
+++ b/src/components/Pages/Search/__tests__/Search.test.tsx
@@ -168,9 +168,11 @@ describe('SearchPage', () => {
     });
 
     expect(
-      screen.getByText('検索に失敗しました。時間をおいて再度お試しください。'),
+      screen.getByText('検索結果を取得できませんでした。もう一度お試しください。'),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'もう一度検索する' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'もう一度検索する' })).toHaveClass(
+      'cursor-pointer',
+    );
     expect(articleListMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isLoading: false,
@@ -236,14 +238,14 @@ describe('SearchPage', () => {
         expect.objectContaining({
           articles: [],
           mixedArticles: [],
-          emptyMessage: '検索に失敗しました。時間をおいて再度お試しください。',
+          emptyMessage: '検索結果を取得できませんでした。もう一度お試しください。',
           isLoading: false,
         }),
       ),
     );
 
     expect(
-      screen.getByText('検索に失敗しました。時間をおいて再度お試しください。'),
+      screen.getByText('検索結果を取得できませんでした。もう一度お試しください。'),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'もう一度検索する' }));

--- a/src/components/Pages/Search/index.tsx
+++ b/src/components/Pages/Search/index.tsx
@@ -14,7 +14,11 @@ import ArticleList from '@/components/Common/ArticleList';
 import AdUnit from '@/components/ThirdParties/GoogleAdSense/Elements/AdUnit';
 import { getApiSearchUrl } from '@/config/publicEnv';
 import { APP_WEBVIEW_QUERY_PARAMETER, APP_WEBVIEW_QUERY_VALUE } from '@/hooks/useAppWebViewMode';
-import { fieldControlClassName, pillControlClassName } from '@/components/Common/controlClassNames';
+import {
+  fieldControlClassName,
+  outlinedControlClassName,
+  pillControlClassName,
+} from '@/components/Common/controlClassNames';
 import { colorClassNames } from '@/styles/designTokens';
 
 type Props = {
@@ -55,6 +59,8 @@ const initialSearchState: SearchState = {
   status: 'idle',
   totalCount: 0,
 };
+
+const SEARCH_REQUEST_TIMEOUT_MS = 12_000;
 
 const getCurrentPage = (page: string | null) => {
   const parsedPage = Number(page);
@@ -182,6 +188,7 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
   const query = useMemo(() => searchParams.get('q')?.trim() ?? '', [searchParams]);
   const currentPage = useMemo(() => getCurrentPage(searchParams.get('page')), [searchParams]);
   const [searchState, setSearchState] = useState<SearchState>(initialSearchState);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     if (!query) {
@@ -189,6 +196,8 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
     }
 
     const abortController = new AbortController();
+    let isActive = true;
+    let timeoutId: number | undefined;
 
     const searchArticles = async () => {
       const endpoint = getApiSearchUrl();
@@ -211,6 +220,7 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
         status: 'loading',
         totalCount: 0,
       });
+      timeoutId = window.setTimeout(() => abortController.abort(), SEARCH_REQUEST_TIMEOUT_MS);
 
       try {
         const response = await fetch(getSearchUrl(endpoint, query, currentPage), {
@@ -236,7 +246,7 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
           totalCount: typeof data.totalCount === 'number' ? data.totalCount : contents.length,
         });
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
+        if (!isActive) {
           return;
         }
 
@@ -257,13 +267,23 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
           status: 'error',
           totalCount: 0,
         });
+      } finally {
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId);
+        }
       }
     };
 
     searchArticles();
 
-    return () => abortController.abort();
-  }, [query, currentPage]);
+    return () => {
+      isActive = false;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+      abortController.abort();
+    };
+  }, [query, currentPage, retryCount]);
 
   const hasCurrentSearchState =
     Boolean(query) && searchState.query === query && searchState.currentPage === currentPage;
@@ -272,7 +292,10 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
   const status = hasCurrentSearchState ? searchState.status : 'idle';
   const isLoading = Boolean(query) && (status === 'idle' || status === 'loading');
 
-  const emptyMessage = '記事はまだありません';
+  const hasSearchError = status === 'error';
+  const emptyMessage = hasSearchError
+    ? '検索に失敗しました。時間をおいて再度お試しください。'
+    : '記事はまだありません';
 
   if (!query && hasAppWebViewParam) {
     return <AppSearchIndex tags={tags} archiveList={archiveList} />;
@@ -288,6 +311,17 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
         tags={tags}
         archiveList={archiveList}
         emptyMessage={emptyMessage}
+        emptyAction={
+          hasSearchError ? (
+            <button
+              type="button"
+              className={`${outlinedControlClassName} px-4 py-2 text-sm font-semibold`}
+              onClick={() => setRetryCount((count) => count + 1)}
+            >
+              もう一度検索する
+            </button>
+          ) : undefined
+        }
         isLoading={isLoading}
         stackedPagination={
           <Pagination

--- a/src/components/Pages/Search/index.tsx
+++ b/src/components/Pages/Search/index.tsx
@@ -294,7 +294,7 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
 
   const hasSearchError = status === 'error';
   const emptyMessage = hasSearchError
-    ? '検索に失敗しました。時間をおいて再度お試しください。'
+    ? '検索結果を取得できませんでした。もう一度お試しください。'
     : '記事はまだありません';
 
   if (!query && hasAppWebViewParam) {
@@ -315,7 +315,7 @@ export default function SearchPage({ recentArticles, tags, archiveList }: Props)
           hasSearchError ? (
             <button
               type="button"
-              className={`${outlinedControlClassName} px-4 py-2 text-sm font-semibold`}
+              className={`${outlinedControlClassName} cursor-pointer px-4 py-2 text-sm font-semibold`}
               onClick={() => setRetryCount((count) => count + 1)}
             >
               もう一度検索する


### PR DESCRIPTION
## 概要

検索APIの初回応答を軽量化し、検索リクエストが完了しない場合も画面が読み込み表示のまま残らないようにします。

## 変更内容

- microCMSの全文検索クエリを利用し、該当記事だけを取得
- microCMSから返却するフィールドを一覧表示に必要な項目へ限定
- 検索語単位のメモリキャッシュへ変更
- 成功した検索APIレスポンスへCDNキャッシュを設定
- ブラウザ側の検索リクエストへ12秒のタイムアウトを追加
- 失敗時にエラー表示と再試行ボタンを表示
- Zenn記事との統合検索と既存ページネーションを維持

## 確認

- lint 成功
- TypeScript型検査 成功
- Vitest 223件成功
- E2E用SSGビルド 成功
- Playwright PC・モバイル 38件成功

Goのvet・テストはGitHub Actionsで確認します。
